### PR TITLE
Postgres Dialect 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
         <jar.finalName>elide-spring-boot</jar.finalName>
         <postgres.version>42.2.7</postgres.version>
         <liquibase.version>3.8.1</liquibase.version>
-        <elide.version>5.0.0-pr25</elide.version>
+        <!-- Change to Version that supports postgres before merge -->
+        <elide.version>5.0.0-pr26-SNAPSHOT</elide.version>
         <spring.version>2.3.4.RELEASE</spring.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
     </properties>
@@ -124,57 +125,18 @@
                 <version>2.22.2</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <version>${spring.version}</version>
-                    </dependency>
-                </dependencies>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.version}</version>
                 <configuration>
-                    <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
-                    <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
+                    <mainClass>example.App</mainClass>
+                    <layout>JAR</layout>
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>repackage</goal>
                         </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/spring.handlers</resource>
-                                </transformer>
-                                <transformer
-                                    implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
-                                    <resource>META-INF/spring.factories</resource>
-                                </transformer>
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/spring.schemas</resource>
-                                </transformer>
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>example.App</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,7 @@
         <jar.finalName>elide-spring-boot</jar.finalName>
         <postgres.version>42.2.7</postgres.version>
         <liquibase.version>3.8.1</liquibase.version>
-        <!-- Change to Version that supports postgres before merge -->
-        <elide.version>5.0.0-pr26-SNAPSHOT</elide.version>
+        <elide.version>5.0.0-pr27</elide.version>
         <spring.version>2.3.4.RELEASE</spring.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
     </properties>

--- a/src/main/java/example/models/ArtifactGroup.java
+++ b/src/main/java/example/models/ArtifactGroup.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Include(rootLevel = true, type = "group")
-@Table(name = "ArtifactGroup")
+@Table(name = "artifactgroup")
 @Entity
 public class ArtifactGroup {
     @Id

--- a/src/main/java/example/models/ArtifactProduct.java
+++ b/src/main/java/example/models/ArtifactProduct.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Include(type = "product")
-@Table(name = "ArtifactProduct")
+@Table(name = "artifactproduct")
 @Entity
 public class ArtifactProduct {
     @Id

--- a/src/main/java/example/models/ArtifactVersion.java
+++ b/src/main/java/example/models/ArtifactVersion.java
@@ -14,7 +14,7 @@ import javax.persistence.Table;
 import java.util.Date;
 
 @Include(type = "version")
-@Table(name = "ArtifactVersion")
+@Table(name = "artifactversion")
 @Entity
 public class ArtifactVersion {
     @Id

--- a/src/main/resources/analytics/models/tables/artifactDownloads.hjson
+++ b/src/main/resources/analytics/models/tables/artifactDownloads.hjson
@@ -1,7 +1,7 @@
 {
     tables: [
     {
-        name: Downloads
+        name: downloads
         table: downloads
         description:
         '''

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,6 +59,9 @@ security:
   origin: "*"
 
 ---
+elide:
+  aggregation-store:
+    default-dialect: Postgres
 
 spring:
   profiles: production

--- a/src/test/java/example/ExampleTest.java
+++ b/src/test/java/example/ExampleTest.java
@@ -5,8 +5,8 @@
  */
 package example;
 
-import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
-import com.yahoo.elide.core.HttpStatus;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.test.graphql.GraphQLDSL;
 import com.yahoo.elide.spring.controllers.JsonApiController;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
@@ -15,20 +15,20 @@ import javax.ws.rs.core.MediaType;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
-import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.field;
-import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.query;
-import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selection;
-import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selections;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationships;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.test.graphql.GraphQLDSL.field;
+import static com.yahoo.elide.test.graphql.GraphQLDSL.query;
+import static com.yahoo.elide.test.graphql.GraphQLDSL.selection;
+import static com.yahoo.elide.test.graphql.GraphQLDSL.selections;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.data;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.relation;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.relationships;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -267,7 +267,7 @@ public class ExampleTest extends IntegrationTest {
     public void testDownloadAPI() throws Exception {
         given()
                 .when()
-                .get("/api/v1/Downloads?fields[Downloads]=downloads,group,product")
+                .get("/api/v1/downloads?fields[downloads]=downloads,group,product")
                 .then()
                 .statusCode(200);
     }


### PR DESCRIPTION
Using newly created Postgres Dialect for Heroku Deployed versions. 

If table names are put in double-quotes, Postgres treats them as case-sensitive names. Postgres Dialect encloses the table and column names in double quotes. Changes were done to make sure the same changelog and queries will work on H2 and Postgres.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
