### PR TITLE
Add native hints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.2</version>
     </parent>
 
     <properties>
         <jar.finalName>elide-spring-boot</jar.finalName>
         <java.version>17</java.version>
 
-        <elide.version>7.0.0-pr5</elide.version>
+        <elide.version>7.0.0-pr6</elide.version>
 
         <springdoc.version>2.1.0</springdoc.version>
         <logback-access-spring-boot-starter.version>4.0.0</logback-access-spring-boot-starter.version>
@@ -89,6 +89,11 @@
                     <groupId>com.vaadin.external.google</groupId>
                     <artifactId>android-json</artifactId>
                 </exclusion>
+                <!-- Remove commons-logging as it conflicts with spring-jcl -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -116,6 +121,13 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
+            <exclusions>
+                <!-- Remove commons-logging as it conflicts with spring-jcl -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -152,6 +164,13 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Remove commons-logging as it conflicts with spring-jcl -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/main/java/example/AppRuntimeHints.java
+++ b/src/main/java/example/AppRuntimeHints.java
@@ -29,6 +29,11 @@ public class AppRuntimeHints implements RuntimeHintsRegistrar {
                 MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
 
         /*
+         * Logback Access Spring
+         */
+        hints.resources().registerPattern("dev/akkinoc/spring/boot/logback/access/logback-access-spring.xml");
+
+        /*
          * ActiveMQ
          */
         hints.resources().registerPattern("activemq-version.properties");
@@ -64,5 +69,11 @@ public class AppRuntimeHints implements RuntimeHintsRegistrar {
 
         hints.reflection().registerType(TypeReference.of("org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields"),
                 MemberCategory.DECLARED_FIELDS);
+
+        /*
+         * Spring Framework springframework.jms.connection.SingleConnectionFactory 
+         */
+        hints.proxies().registerJdkProxy(jakarta.jms.Connection.class, jakarta.jms.QueueConnection.class,
+                jakarta.jms.TopicConnection.class);
     }
 }


### PR DESCRIPTION
Adds some missing native hints. Tested by compiling to native and manually exercising functions.

This also excludes `commons-logging` as it conflicts with `spring-jcl` and potentially causes the native build to fail.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
